### PR TITLE
Remove description variable from google project module

### DIFF
--- a/helpers.tofu
+++ b/helpers.tofu
@@ -2,5 +2,5 @@
 # https://github.com/osinfra-io/pt-arche-core-helpers
 
 module "core_helpers" {
-  source = "github.com/osinfra-io/pt-arche-core-helpers//child?ref=1024a5446b33be60bba2d52897ba4f487cb469ed"  # v0.2.3
+  source = "github.com/osinfra-io/pt-arche-core-helpers//child?ref=1024a5446b33be60bba2d52897ba4f487cb469ed" # v0.2.3
 }

--- a/locals.tofu
+++ b/locals.tofu
@@ -3,7 +3,7 @@
 
 locals {
   audit_log_config_types        = toset(["ADMIN_READ", "DATA_READ", "DATA_WRITE"])
-  base_project_id               = "${var.prefix}-${var.description}-${module.core_helpers.env}"
+  base_project_id               = "${var.prefix}-${module.core_helpers.env}"
   billing_budget_display_name   = "Monthly: ${google_project.this.project_id}"
   billing_budget_project_filter = "projects/${google_project.this.number}"
 
@@ -110,7 +110,7 @@ locals {
   # Format Function
   # https://opentofu.org/docs/language/functions/format
 
-  project_id = var.random_project_id ? format("%s-%s-%s-%s", var.prefix, var.description, random_id.this.hex, module.core_helpers.env) : local.base_project_id
+  project_id = var.random_project_id ? format("%s-%s-%s", var.prefix, random_id.this.hex, module.core_helpers.env) : local.base_project_id
 
   # Concat Function
   # https://opentofu.org/docs/language/functions/concat

--- a/tests/fixtures/default/main.tofu
+++ b/tests/fixtures/default/main.tofu
@@ -20,7 +20,6 @@ module "google_project" {
 
   billing_account                 = "000000-000000-000000"
   cis_2_2_logging_sink_project_id = var.cis_2_2_logging_sink_project_id
-  description                     = "mock"
   folder_id                       = "0000000000000"
 
   labels = {

--- a/tests/fixtures/logging/main.tofu
+++ b/tests/fixtures/logging/main.tofu
@@ -20,7 +20,6 @@ module "google_project" {
 
   billing_account               = "000000-000000-000000"
   cis_2_2_logging_bucket_locked = false
-  description                   = "mock"
   folder_id                     = "0000000000000"
 
   labels = {

--- a/variables.tofu
+++ b/variables.tofu
@@ -30,11 +30,6 @@ variable "deletion_policy" {
   default     = "PREVENT"
 }
 
-variable "description" {
-  description = "A short description representing the system, or service you're building in the project for example: `tools` (for a tooling project), `logging` (for a logging project), `services` (for a services project)"
-  type        = string
-}
-
 variable "folder_id" {
   description = "The numeric ID of the folder this project should be created under. Only one of `org_id` or `folder_id` may be specified"
   type        = string


### PR DESCRIPTION
## Summary

Removes `var.description` entirely from the module. Project IDs now use the format `{prefix}-{random}-{env}` instead of `{prefix}-{description}-{random}-{env}`.

This is part of a larger re-architecture to rename "kubernetes projects" to "platform-managed projects" in pt-corpus so that managed data services (Cloud SQL, Redis) can coexist with GKE clusters in the same project.

## Changes

- `variables.tofu`: Remove `var.description`
- `locals.tofu`: Update `base_project_id` and `project_id` to drop the description segment
- `tests/fixtures/default/main.tofu`: Remove `description = "mock"`
- `tests/fixtures/logging/main.tofu`: Remove `description = "mock"`

## Migration note

This is a **breaking change** for any caller currently passing `description`. All callers in `pt-corpus` will be updated in a follow-up PR to remove the `description` argument in lockstep. Since the project ID format changes, existing projects will need `tofu state rm` + recreate — GCP project IDs are immutable.

## Release

MINOR version bump → **v0.7.0**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed `description` input variable from module configuration
  * Updated project ID generation logic to exclude the description component
  * Updated test fixtures accordingly

<!-- end of auto-generated comment: release notes by coderabbit.ai -->