### PR TITLE
Replace count with lifecycle { enabled } on google_project_service_identity.logging

### DIFF
--- a/locals.tofu
+++ b/locals.tofu
@@ -89,9 +89,9 @@ locals {
     for k, v in local.cis_logging_metrics : k => merge({ status = v.status }, var.labels)
   }
 
-  logging_service_identity_count  = var.cis_2_2_logging_sink_project_id == "" ? 1 : 0
-  logging_service_identity_email  = length(google_project_service_identity.logging) > 0 ? google_project_service_identity.logging[0].email : null
-  logging_service_identity_member = try("serviceAccount:${google_project_service_identity.logging[0].email}", "serviceAccount:pending@pending.iam.gserviceaccount.com")
+  logging_service_identity_email   = google_project_service_identity.logging != null ? google_project_service_identity.logging.email : null
+  logging_service_identity_enabled = var.cis_2_2_logging_sink_project_id == ""
+  logging_service_identity_member  = try("serviceAccount:${google_project_service_identity.logging.email}", "serviceAccount:pending@pending.iam.gserviceaccount.com")
 
   monitoring_notification_channels = {
     "budget" = {

--- a/main.tofu
+++ b/main.tofu
@@ -283,11 +283,13 @@ resource "google_project_service" "this" {
 # https://search.opentofu.org/provider/hashicorp/google/latest/docs/resources/project_service_identity
 
 resource "google_project_service_identity" "logging" {
-  count = local.logging_service_identity_count
-
   depends_on = [
     google_project_service.this
   ]
+
+  lifecycle {
+    enabled = local.logging_service_identity_enabled
+  }
 
   provider = google-beta # Required for google_project_service_identity
 


### PR DESCRIPTION
Closes #178

## Changes

- **`locals.tofu`**: Renamed `logging_service_identity_count` → `logging_service_identity_enabled` (converting `1/0` to `true/false`). Updated `logging_service_identity_email` to use a null-check on the resource object instead of `length()` + `[0]` indexing. Dropped `[0]` from `logging_service_identity_member`'s `try()` call. Kept locals in alphabetical order (`email`, `enabled`, `member`).
- **`main.tofu`**: Replaced `count = local.logging_service_identity_count` with `lifecycle { enabled = local.logging_service_identity_enabled }`. Meta-arguments remain alphabetical (`depends_on`, `lifecycle`, `provider`).

No `moved` block required — OpenTofu v1.11+ automatically handles state migration from the `count`-indexed address to the unindexed address when switching to `lifecycle { enabled }`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved logging service identity resolution mechanism for more efficient resource configuration.
  * Simplified resource enablement logic to use provider-native lifecycle management instead of conditional counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->