### PR TITLE
Ensure logging service identity exists before IAM binding for team projects

### DIFF
--- a/locals.tofu
+++ b/locals.tofu
@@ -90,7 +90,7 @@ locals {
   }
 
   logging_service_identity_email   = google_project_service_identity.logging != null ? google_project_service_identity.logging.email : null
-  logging_service_identity_enabled = var.cis_2_2_logging_sink_project_id == ""
+  logging_service_identity_enabled = true
   logging_service_identity_member  = try("serviceAccount:${google_project_service_identity.logging.email}", "serviceAccount:pending@pending.iam.gserviceaccount.com")
 
   monitoring_notification_channels = {

--- a/main.tofu
+++ b/main.tofu
@@ -263,6 +263,8 @@ resource "google_project_iam_member" "cis_2_2" {
     enabled = var.cis_2_2_logging_sink_project_id != ""
   }
 
+  depends_on = [google_project_service_identity.logging]
+
   member  = google_logging_project_sink.cis_2_2_logging_sink.writer_identity
   project = local.cis_2_2_logging_sink_project_id
   role    = "roles/logging.bucketWriter"


### PR DESCRIPTION
## Problem

When a new team project sinks logs to a corpus platform project, corpus applies `roles/logging.bucketWriter` on the platform project for the team's logging SA (`service-{number}@gcp-sa-logging.iam.gserviceaccount.com`). This fails with:

```
Error 400: Service account service-{number}@gcp-sa-logging.iam.gserviceaccount.com does not exist., badRequest
```

**Root cause:** `google_project_service_identity.logging` is only enabled when `cis_2_2_logging_sink_project_id == ""` (self-sink / platform projects). For team projects the service identity is never explicitly provisioned, so GCP hasn't created the logging SA yet when the IAM binding is applied.

## Fix

- Always enable `google_project_service_identity.logging` so the logging SA is provisioned for every project
- Add `depends_on = [google_project_service_identity.logging]` to `google_project_iam_member.cis_2_2` so the IAM binding waits until the SA exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resource provisioning order to ensure logging service identity is created before IAM permissions are applied, preventing deployment failures.

* **Refactor**
  * Simplified logging service identity configuration logic to streamline deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->