### PR TITLE
Add dynamic prevent_destroy and destroy = false for KMS crypto key

### DIFF
--- a/main.tofu
+++ b/main.tofu
@@ -60,16 +60,9 @@ resource "google_compute_project_metadata_item" "enable_oslogin" {
 
 resource "google_kms_crypto_key" "cis_2_2_logging_sink" {
   lifecycle {
-    enabled = var.cis_2_2_logging_sink_project_id == ""
-
-    # We can't use the lifecycle block to prevent destroy on this resource for testing purposes.
-    # CryptoKeys cannot be deleted from Google Cloud Platform. Destroying a OpenTofu-managed CryptoKey will
-    # remove it from state and delete all CryptoKeyVersions, rendering the key unusable, but will not delete
-    # the resource from the project. When OpenTofu destroys these keys, any data previously encrypted with
-    # these keys will be irrecoverable. For this reason, it is strongly recommended that you add lifecycle
-    # hooks to the resource to prevent accidental destruction.
-
-    # prevent_destroy = true
+    destroy         = false
+    enabled         = var.cis_2_2_logging_sink_project_id == ""
+    prevent_destroy = var.prevent_destroy
   }
 
   key_ring        = google_kms_key_ring.this.id

--- a/variables.tofu
+++ b/variables.tofu
@@ -59,6 +59,12 @@ variable "prefix" {
   default     = "test"
 }
 
+variable "prevent_destroy" {
+  description = "If true, prevents the KMS crypto key from being destroyed"
+  type        = bool
+  default     = false
+}
+
 variable "random_project_id" {
   description = "If true, a random hex value with a prefix of tf will be added to the `project_id`"
   type        = bool


### PR DESCRIPTION
Leverages OpenTofu v1.12.0 features for the KMS crypto key lifecycle:

- **Dynamic `prevent_destroy`** — adds `var.prevent_destroy` (bool, default `false`) so production callers can set `prevent_destroy = true` instead of relying on the old commented-out workaround
- **`destroy = false`** — KMS CryptoKeys cannot be truly deleted from GCP; this makes the intent explicit so if the resource is ever removed from config, OpenTofu removes it from state only — no CryptoKeyVersions are deleted and no data becomes irrecoverable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * KMS crypto key destruction is now controllable through a configurable variable, defaulting to allow destruction when not specified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-arche-google-project/pull/183)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->