### PR TITLE
Restrict pull_request_target event types in Dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,6 +1,8 @@
 name: Dependabot Approve and Merge
 
-on: pull_request_target
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

The `pull_request_target` trigger runs with base repository privileges and has access to repository secrets. Without explicit event type filters, it fires on all default PR event types.

This PR adds explicit `types: [opened, synchronize, reopened]` to the trigger (which was already the implicit default). Making it explicit:
- Documents the intended trigger scope
- Reduces the attack surface surface by being explicit rather than relying on defaults
- Follows the principle of explicit over implicit

Existing security mitigations remain in place:
- `github.actor == 'dependabot[bot]'` guard in the reusable called workflow
- No PR head code is checked out or executed
- Privileged operations use a GitHub App token, not `GITHUB_TOKEN`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to explicitly trigger on specific pull request events (opened, synchronize, and reopened), improving automation efficiency and clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-arche-google-project/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->